### PR TITLE
Update entrypoint.sh

### DIFF
--- a/script/entrypoint.sh
+++ b/script/entrypoint.sh
@@ -64,7 +64,7 @@ if [ "$AIRFLOW__CORE__EXECUTOR" != "SequentialExecutor" ]; then
   wait_for_port "Postgres" "$POSTGRES_HOST" "$POSTGRES_PORT"
 fi
 
-if [ "$AIRFLOW__CORE__EXECUTOR" = "CeleryExecutor" ]; then
+if [ -z "$AIRFLOW__CELERY__NO_DEFAULT_BROKER_URL" && "$AIRFLOW__CORE__EXECUTOR" = "CeleryExecutor" ]; then
   AIRFLOW__CELERY__BROKER_URL="redis://$REDIS_PREFIX$REDIS_HOST:$REDIS_PORT/1"
   wait_for_port "Redis" "$REDIS_HOST" "$REDIS_PORT"
 fi


### PR DESCRIPTION
added $AIRFLOW__CELERY__NO_DEFAULT_BROKER_URL to allow for alternative brokers (rabbitmq in my case) using airflow.cfg